### PR TITLE
Better split view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -295,6 +295,7 @@ dependencies = [
  "monaco",
  "serde",
  "serde_json",
+ "split-yew",
  "thiserror",
  "time",
  "tracing",
@@ -351,7 +352,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -732,9 +733,9 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -897,7 +898,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -977,7 +978,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1022,7 +1023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1034,7 +1035,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -1051,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1077,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -1289,7 +1290,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1360,10 +1361,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "split-yew"
+version = "0.1.0"
+source = "git+https://github.com/aleb2000/split-yew?branch=yew-playground#60422c1dd1d6b59dbb95ea5fb4387281341b972d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1407,7 +1430,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1492,7 +1515,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1600,7 +1623,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1740,9 +1763,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1752,16 +1775,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
  "wasm-bindgen-shared",
 ]
 
@@ -1779,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1789,28 +1812,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1982,7 +2005,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2009,5 +2032,5 @@ source = "git+https://github.com/yewstack/yew/#da09755c27bfeb113e0c4b1096214a826
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "split-yew"
 version = "0.1.0"
-source = "git+https://github.com/aleb2000/split-yew?branch=yew-playground#60422c1dd1d6b59dbb95ea5fb4387281341b972d"
+source = "git+https://github.com/aleb2000/split-yew?branch=yew-playground#8f22a9c32bdf5f06e0b6c172f85b9fd98940e543"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -25,4 +25,5 @@ thiserror = { workspace = true }
 tracing = { workspace = true, default-features = false }
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tracing-subscriber = { workspace = true, features = ["time"] }
-split-yew = { git = "https://github.com/aleb2000/split-yew", branch = "yew-playground"}
+
+split-yew = { git = "https://github.com/aleb2000/split-yew", branch = "yew-playground" }

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-yew = { git = "https://github.com/yewstack/yew/", features = ["csr"] }
-yew-router = { git = "https://github.com/yewstack/yew/" }
+yew = { version = "0.20", features = ["csr"] }
+yew-router = "0.17"
 
 wasm-bindgen = "0.2.78"
 wasm-bindgen-futures = "0.4"
@@ -14,7 +14,7 @@ web-sys = { version = "0.3", features = ["HtmlCollection"] }
 
 gloo = "0.8"
 gloo-net = { version = "0.2.4", features = ["http", "json"] }
-monaco = { git = "https://github.com/hamza1311/rust-monaco", branch = "yew-playground", features = ["yew-components"] }
+monaco = { git = "https://github.com/siku2/rust-monaco", features = ["yew-components"] }
 tracing-web = "0.1.2"
 
 anyhow = { workspace = true }
@@ -26,4 +26,4 @@ tracing = { workspace = true, default-features = false }
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tracing-subscriber = { workspace = true, features = ["time"] }
 
-split-yew = { git = "https://github.com/aleb2000/split-yew", branch = "yew-playground" }
+split-yew = "0.1.1"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -25,3 +25,4 @@ thiserror = { workspace = true }
 tracing = { workspace = true, default-features = false }
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tracing-subscriber = { workspace = true, features = ["time"] }
+split-yew = { git = "https://github.com/aleb2000/split-yew", branch = "yew-playground"}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,13 @@
     <link data-trunk href="static" rel="copy-dir">
     <link rel="icon" href="/static/favicon.ico" sizes="any">
     <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
+	<script type="importmap">
+		{
+			"imports": {
+				"split.js": "https://unpkg.com/split.js@1.6.5/dist/split.es.js"
+			}
+		}
+	</script>
 </head>
 <body class="text-gray-200 h-screen"></body>
 </html>

--- a/frontend/src/components/output.rs
+++ b/frontend/src/components/output.rs
@@ -1,5 +1,5 @@
-use crate::{ActionButtonState, ActionButtonStateContext};
 use crate::api::BACKEND_URL;
+use crate::{ActionButtonState, ActionButtonStateContext};
 use gloo_net::http::QueryParams;
 use std::rc::Rc;
 use yew::prelude::*;
@@ -39,8 +39,6 @@ pub fn OutputContainer(props: &OutputContainerProps) -> Html {
     let classes = classes!(
         "w-full",
         "h-full",
-        "border-t-[10px]",
-        "border-gray-400",
         "border-solid",
         if *loading { "invisible" } else { "visible" }
     );

--- a/frontend/src/components/output.rs
+++ b/frontend/src/components/output.rs
@@ -39,7 +39,6 @@ pub fn OutputContainer(props: &OutputContainerProps) -> Html {
     let classes = classes!(
         "w-full",
         "h-full",
-        "border-solid",
         if *loading { "invisible" } else { "visible" }
     );
     html! {

--- a/frontend/styles/globals.scss
+++ b/frontend/styles/globals.scss
@@ -9,6 +9,19 @@
     box-sizing: border-box;
 }
 
+/* For Split.js */
+.gutter {
+	background-color: #9ca3af;
+}
+
+.gutter.gutter-vertical {
+	cursor: row-resize;
+}
+
+.gutter.gutter-horizontal {
+	cursor: col-resize;
+}
+
 /*
 body {
     height: 100vh;


### PR DESCRIPTION
This PR also updates some web-sys related dependencies to a newer minor version (simply because split-yew is already using the newer version).

* The split view is initially collapsed.
* The draggable gutter is always visible, so the user can always drag it wherever it wants anyway.
* On first run it will automatically resize to a 50/50 split.
* The split does not use a grid layout anymore but a flex one instead (Split.js does not support grid layouts, there is a split-grid version that does but my library currently does not support that). The grid layout wasn't doing much anyway.
* I did not add any buttons to collapse the split, but if you want it, that can be easily done by setting the "output_collapsed" state variable to true.